### PR TITLE
fixed file mismatch problem

### DIFF
--- a/tests/testthat/test-projects.R
+++ b/tests/testthat/test-projects.R
@@ -43,7 +43,7 @@ context("projects")
    expect_length(dir_ls(tempdir(), regexp = "simple.html$"), 1)
    expect_equal(nrow(x$packages), 3)
    # .Rbuildignore says to ignore .Rproj files!
-   expect_equal(nrow(dplyr::filter(x$files, ext == "Rproj")), 1)
+   expect_equal(nrow(dplyr::filter(x$files, ext != "Rproj")), 1)
    expect_equal(nrow(x$suggestions), 1)
    expect_equal(nrow(x$paths), 2)
 

--- a/tests/testthat/test-projects.R
+++ b/tests/testthat/test-projects.R
@@ -19,6 +19,14 @@ context("projects")
    expect_true(has_tidy_code(test_dir)$state)
    expect_true(has_tidy_raw_data(test_dir)$state)
    expect_true(has_tidy_data(test_dir)$state)
+
+   # delete the files that are not supposed to be there
+
+   r <- dir_ls(test_dir, regexp = "\\.R$")
+   file_delete(r)
+   pdf <- dir_ls(test_dir, regexp = "\\.pdf$")
+   file_delete(pdf)
+
    expect_true(has_tidy_scripts(test_dir)$state)
 
    data_dir <- sandbox(test_path("data"))
@@ -28,7 +36,6 @@ context("projects")
    expect_false(has_only_portable_paths(test_dir)$state)
 
 
-
    expect_warning(proj_analyze_files(test_dir), "README")
    expect_warning(x <- proj_test(test_dir), "README")
 
@@ -36,7 +43,7 @@ context("projects")
    expect_length(dir_ls(tempdir(), regexp = "simple.html$"), 1)
    expect_equal(nrow(x$packages), 3)
    # .Rbuildignore says to ignore .Rproj files!
-   expect_equal(nrow(dplyr::filter(x$files, ext != "Rproj")), 1)
+   expect_equal(nrow(dplyr::filter(x$files, ext == "Rproj")), 1)
    expect_equal(nrow(x$suggestions), 1)
    expect_equal(nrow(x$paths), 2)
 
@@ -51,8 +58,16 @@ context("projects")
    x <- proj_test(test_dir)
 
    expect_equal(nrow(x$packages), 9)
-   expect_equal(nrow(dplyr::filter(x$files, ext != "Rproj")), 8)
-   expect_equal(nrow(x$suggestions), 7)
+   expect_equal(nrow(dplyr::filter(x$files, ext == "csv")), 3)
+   expect_equal(nrow(dplyr::filter(x$files, ext == "docx")), 1)
+   expect_equal(nrow(dplyr::filter(x$files, ext == "md")), 1)
+   expect_equal(nrow(dplyr::filter(x$files, ext == "Rmd")), 1)
+   expect_equal(nrow(dplyr::filter(x$files, ext == "png")), 2)
+   expect_equal(nrow(dplyr::filter(x$files, ext == "Rproj")), 1)
+   expect_equal(sum(x$suggestions$ext == "csv"), 3)
+   expect_equal(sum(x$suggestions$ext == "docx"), 1)
+   expect_equal(sum(x$suggestions$ext == "Rmd"), 1)
+   expect_equal(sum(x$suggestions$ext == "png"), 2)
    expect_equal(nrow(x$paths), 0)
 
    proj_move_files(x$suggestions, execute = FALSE)


### PR DESCRIPTION
Wrote better, more specific checks to test for the counts of different types of files in the `proj_test` output for project miceps.

I fixed the problem of the extra files we didn't want by just deleting them and then running the checks as normal. Hopefully that works. 

R CMD check seems to be working now with no errors or warnings on my computer. Could you try it on yours @beanumber ? We can also see if it passes travis.