### PR TITLE
deleted extra files in more spots

### DIFF
--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -78,6 +78,8 @@ test_that("has functions work", {
 
   data_dir <- sandbox(test_path("data"))
 
+  r <- dir_ls(noob, regexp = "\\.R$")
+  file_delete(r)
 
   expect_true(has_no_randomness(noob)$state)
   expect_false(has_no_randomness(random)$state)
@@ -87,6 +89,12 @@ test_that("has functions work", {
   expect_false(has_only_portable_paths(noob)$state)
 
   miceps <- test_path("project_miceps")
+
+  r <- dir_ls(miceps, regexp = "\\.R$")
+  file_delete(r)
+  pdf <- dir_ls(miceps, regexp = "\\.pdf$")
+  file_delete(pdf)
+
   expect_false(has_only_used_files(miceps)$state)
   expect_true(has_only_used_files(random)$state)
 

--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -5,6 +5,13 @@ test_that("has functions work", {
   dir <- test_path("project_noob")
   test_dir <- sandbox(dir)
 
+  # delete files we don't want
+
+  r <- dir_ls(test_dir, regexp = "\\.R$")
+  file_delete(r)
+  pdf <- dir_ls(test_dir, regexp = "\\.pdf$")
+  file_delete(pdf)
+
   # project roots
 
   expect_true(has_proj_root(test_dir)$state)
@@ -13,6 +20,12 @@ test_that("has functions work", {
   expect_false(has_proj_root(test_dir)$state)
 
   test_dir <- sandbox(dir)
+
+  r <- dir_ls(test_dir, regexp = "\\.R$")
+  file_delete(r)
+  pdf <- dir_ls(test_dir, regexp = "\\.pdf$")
+  file_delete(pdf)
+
   expect_true(has_no_nested_proj_root(test_dir)$state)
   dir_create(path(test_dir, "R"))
   fake <- path(test_dir, "R", "fake.Rproj")
@@ -20,6 +33,12 @@ test_that("has functions work", {
   expect_false(has_no_nested_proj_root(test_dir)$state)
 
   test_dir <- sandbox(dir)
+
+  r <- dir_ls(test_dir, regexp = "\\.R$")
+  file_delete(r)
+  pdf <- dir_ls(test_dir, regexp = "\\.pdf$")
+  file_delete(pdf)
+
   expect_false(has_readme(test_dir)$state)
   readme <- path(test_dir, "README.md")
   file_create(readme)
@@ -41,6 +60,12 @@ test_that("has functions work", {
   expect_true(has_tidy_data(test_dir)$state)
 
   test_dir <- sandbox(dir)
+
+  r <- dir_ls(test_dir, regexp = "\\.R$")
+  file_delete(r)
+  pdf <- dir_ls(test_dir, regexp = "\\.pdf$")
+  file_delete(pdf)
+
   expect_true(has_tidy_scripts(test_dir)$state)
   file_create(path(test_dir, "second.R"))
   expect_false(has_tidy_scripts(test_dir)$state)


### PR DESCRIPTION
Looks like the reason why travis was failing is that it was still finding some of those bad files we didn't want during some checks from `test_check.R`. Before, I'd only deleted the bad files for checks in `test_projects.R`. Now, I added some lines deleting the bad files out of the directory each time we sandbox and it's still passing R CMD check for me. This might fix the problem. The number of deletions seems a bit excessive, so if you think I should only do the deletion once, please let me know and I can easily fix it.