### PR TITLE
fixed search path problem (issue #7)

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -623,7 +623,7 @@ has_no_lint <- function(path = ".") {
     problem = "Your code does not conform to tidyverse style",
     solution = "Fix code accordinng to Markers. Use usethis::use_tidy_style() to change automatically",
     help = "?usethis::use_tidy_style",
-    errors = NULL
+    errors = tibble(culprit = "See 'Markers' tab in Console window to find which code was flagged")
   )
 }
 attr(has_no_lint, "req_compilation") <- FALSE

--- a/R/shims.R
+++ b/R/shims.R
@@ -503,6 +503,8 @@ library <- function(package,
                     verbose = getOption("verbose")
 ) {
 
+  detach(package:fertile)
+
 
   if(interactive_log_on()){
   if (!missing(package)) {
@@ -538,6 +540,9 @@ library <- function(package,
   }
 
   }
+
+  suppressMessages(base::require(fertile))
+
 }
 
 #' @rdname shims
@@ -551,6 +556,8 @@ require <- function(package,
                     warn.conflicts = TRUE,
                     character.only = FALSE) {
 
+
+  detach(package:fertile)
 
   if(interactive_log_on()){
   package <- package_name(rlang::enquo(package),
@@ -567,6 +574,8 @@ require <- function(package,
   )
 
   }
+
+  suppressMessages(base::require(fertile))
 }
 
 package_name <- function(package, character.only = FALSE) {


### PR DESCRIPTION
Forced `fertile` to the top of the search path when `library()` or `require()` is called.  This seems to work in my testing and should solve the issue we were having!

This pull request also includes an older update where I changed a NULL error message that was being provided to users to something more informative.