### PR TITLE
edited `proj_pkg_script` to address issue #69

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,7 @@ Description: Make creating a reproducible project as easy as possible,
   analysis project as `goodpractice` is to an R package. 
 Depends: R (>= 3.4.0)
 Imports:
+    available,
     cli,
     crayon,
     downloader,

--- a/R/fertile.R
+++ b/R/fertile.R
@@ -187,12 +187,15 @@ proj_analyze_pkgs <- function(path = ".") {
 generate_script <- function(pkg_name, vector = c()) {
 
   # check if package is available on CRAN
-  not_on_cran <- as.logical(available::available_on_cran((pkg_name)))
+  pkg_on_cran <- !as.logical(available::available_on_cran((pkg_name)))
+  pkg_on_github <- !as.logical(available::available_on_github((pkg_name)))[1]
 
-  if(not_on_cran == TRUE){
-    new_line <- sprintf("#Package '%s' not available on CRAN. Look on Github for the package author instead", pkg_name)
-  }else{
+  if(pkg_on_cran == TRUE){
     new_line <- sprintf("install.packages('%s')", pkg_name)
+  }else if(pkg_on_github == TRUE){
+    new_line <- sprintf("#Package '%s' is located on GitHub. Find its author and install using devtools::install_github()", pkg_name)
+  }else{
+    new_line <- sprintf("#Package '%s' is not located on CRAN or GitHub", pkg_name)
   }
 
   vector <- c(vector, new_line)

--- a/R/fertile.R
+++ b/R/fertile.R
@@ -186,7 +186,15 @@ proj_analyze_pkgs <- function(path = ".") {
 
 generate_script <- function(pkg_name, vector = c()) {
 
-  new_line <- sprintf("install.packages('%s')", pkg_name)
+  # check if package is available on CRAN
+  not_on_cran <- as.logical(available::available_on_cran((pkg_name)))
+
+  if(not_on_cran == TRUE){
+    new_line <- sprintf("#Package '%s' not available on CRAN. Look on Github for the package author instead", pkg_name)
+  }else{
+    new_line <- sprintf("install.packages('%s')", pkg_name)
+  }
+
   vector <- c(vector, new_line)
   vector
 
@@ -204,10 +212,11 @@ proj_pkg_script <- function(path = ".") {
 
   # Delete the existing script (if it exists) so we can overwrite it
   if(file.exists(fs::path(path,"install_proj_packages.r"))){
-    file_delete(fs::path(path,"install_proj_packages.r"))
+    fs::file_delete(fs::path(path,"install_proj_packages.r"))
   }
 
   pkgs <- proj_analyze_pkgs(path)$package
+
 
   install_calls <- purrr::map_chr(pkgs, generate_script)
 
@@ -217,6 +226,8 @@ proj_pkg_script <- function(path = ".") {
       sep="\n ",
       append=TRUE)
 }
+
+
 
 
 #' Render files in a project directory to update the render log file

--- a/R/fertile.R
+++ b/R/fertile.R
@@ -193,7 +193,7 @@ generate_script <- function(pkg_name, vector = c()) {
   if(pkg_on_cran == TRUE){
     new_line <- sprintf("install.packages('%s')", pkg_name)
   }else if(pkg_on_github == TRUE){
-    new_line <- sprintf("#Package '%s' is located on GitHub. Find its author and install using devtools::install_github()", pkg_name)
+    new_line <- sprintf("#Package '%s' is located on GitHub. Find its author and install using remotes::install_github()", pkg_name)
   }else{
     new_line <- sprintf("#Package '%s' is not located on CRAN or GitHub", pkg_name)
   }


### PR DESCRIPTION
In an attempt to address #69, `proj_pkg_script()` now differentiates between CRAN and GitHub packages during the process of generating its install script and also finds if packages are not available on either site. 

The line that gets added to the install script is now different based on package location:
CRAN packages get `install.packages()`
GitHub packages get a comment saying the package is on GitHub but an author name and `install_github()` are required to install
Packages on neither site get a comment saying just that.

This way, all of the packages that appear in an Rproj folder still receive a line in the package install script so it is clear that they were used, but not all receive calls to `install.packages()` that would fail if run.