### PR TITLE
Fixed proj_analyze() bug and has_no_randomness() issue

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -719,6 +719,7 @@ has_no_randomness <- function(path = ".") {
     }
   }
 
+
   # If seeds are the same, not flagged
   if (identical(seed_old, seed_new)) {
     result = TRUE

--- a/R/checks.R
+++ b/R/checks.R
@@ -432,7 +432,7 @@ has_well_commented_code <- function(path = ".") {
 
   make_check(
     name = "Checking that code is adequately commented",
-    state = length(bad) == 0,
+    state = length(bad$file_name) == 0,
     problem = "Suboptimally commented .R or .Rmd files found",
     solution = "Add more comments to the files below. At least 10% of the lines should be comments.",
     help = "https://intelligea.wordpress.com/2013/06/30/inline-and-block-comments-in-r/",

--- a/R/checks.R
+++ b/R/checks.R
@@ -681,53 +681,43 @@ has_no_randomness <- function(path = ".") {
   seeds <- log %>%
     filter(func == "base::set.seed")
 
-  seed_old <- log %>%
+  seed_old <- as.numeric(log %>%
     filter(path == "Seed @ Start") %>%
-    select(func)
+    select(func))
 
-  seed_new <- log %>%
+  seed_new <- as.numeric(log %>%
     filter(path == "Seed @ End") %>%
-    select(func)
+    select(func))
 
-  read_csv_calls <- log %>%
-    filter(func == "readr::read_csv")
+  read_csv_calls <- grep("readr::read_csv", log$func)
 
   read_csv_caused_problem <- FALSE
-  RNG_found <- FALSE
 
+  # If there are calls to read_csv
+  if (length(read_csv_calls)>0){
 
-  # See if read_csv caused an issue (since it now changes random number generation)
-  all_files_list <- c(fs::as_fs_path(fs::dir_ls(proj_root(path), recurse = TRUE)))
-  all_files <- tibble(path_abs = all_files_list)
+    # Go through each call one at a time
+    for (call in read_csv_calls){
+      # Check the seed before and the seed after
+      seed_before <- log$func[call - 1]
+      seed_after <- log$func[call + 1]
 
-  r_files <- all_files %>%
-    filter(tools::file_ext(path_abs) %in% c("rmd", "Rmd", "R", "r"))
+      # If the seed before was the same as the seed either at the start of the file or
+      # after the LAST time we ran read_csv then we can update our existing seed
+      # (as if no randomness has occurred)
 
-  code_lines <- c()
-  for (file in r_files$path_abs){
-    lines <- readr::read_lines(file)
-    code_lines <- code_lines %>% append(lines)
+      if (seed_before == seed_old){
+        seed_old <- seed_after
+      }
+    }
+
+    # If we do this updating and see no randomness OTHER than from read_csv
+    # then we know read_csv was the problem
+
+    if (seed_old == seed_new){
+      read_csv_caused_problem <- TRUE
+    }
   }
-
-  output <- c()
-  #Random numbers generate elsewhere?
-  rng_functions <- c('runif\\(', 'rbinom\\(', 'rnorm\\(', 'sample\\(', 'sample_frac\\(', 'sample_n\\(', 'slice_sample\\(',
-                     'rgamma\\(', 'rpois\\(', 'rexp\\(', 'rmvnorm\\(', 'rnbinom\\(', 'rbeta\\(', 'rchisq\\(', 'rlogis\\(',
-                     'rstab\\(', 'rt\\(', 'rgeom\\(', 'rhyper\\(', 'rwilcox\\(', 'rweibull\\(')
-
-  for (func in rng_functions){
-    found <- grep(func, code_lines)
-    output <- output %>% append(found)
-  }
-
-  if (length(output) > 0){
-    RNG_found <- TRUE
-  }
-
-  if (nrow(read_csv_calls)>0 & RNG_found == FALSE & !identical(seed_old,seed_new)){
-    read_csv_caused_problem <- TRUE
-  }
-
 
   # If seeds are the same, not flagged
   if (identical(seed_old, seed_new)) {

--- a/R/fertile.R
+++ b/R/fertile.R
@@ -284,13 +284,13 @@ proj_render <- function(path = ".", ...) {
 
   msg("Rendering R scripts...")
 
-  if(Sys.getenv("IN_TESTTHAT") != TRUE){
-    log_push(x = "Seed @ Start", .f = .Random.seed[2], path = path)
-  }
 
-  if(Sys.getenv("IN_TESTTHAT") == TRUE){
-    log_push(x = "Seed @ Start", .f = "Seed 1", path = path)
+  seed <- get0(".Random.seed", envir = .GlobalEnv, ifnotfound = NULL)
+  if (is.null(seed)){
+      # Force a random seed to exist if there isn't one
+      x <- stats::rnorm(1,0,1)
   }
+  log_push(x = "Seed @ Start", .f = .Random.seed[2], path = path)
 
 
   # find all R, Rmd, rmd files and run them?

--- a/R/fertile.R
+++ b/R/fertile.R
@@ -326,13 +326,8 @@ proj_render <- function(path = ".", ...) {
   )
 
 
-  if(Sys.getenv("IN_TESTTHAT") != TRUE){
-    log_push(x = "Seed @ End", .f = .Random.seed[2], path = path)
-  }
+  log_push(x = "Seed @ End", .f = .Random.seed[2], path = path)
 
-  if(Sys.getenv("IN_TESTTHAT") == TRUE){
-    log_push(x = "Seed @ End", .f = "Seed 2", path = path)
-  }
 
   # even if a file is empty, its render log will not be
   log_push(x = "LAST RENDERED", .f = "proj_render", path = path)

--- a/R/shims.R
+++ b/R/shims.R
@@ -104,10 +104,23 @@ read.table <- function(file, ...) {
 #' @export
 
 read_csv <- function(file, ...) {
+
   if (interactive_log_on()) {
+    if (Sys.getenv("FERTILE_RENDER_MODE") == TRUE){
+      log_push('Seed Before', .Random.seed[2])
+    }
+
     log_push(file, "readr::read_csv")
+
     check_path_safe(file, ... = "readr::read_csv")
-    readr::read_csv(file, ...)
+
+    data <- readr::read_csv(file, ...)
+
+    if (Sys.getenv("FERTILE_RENDER_MODE") == TRUE){
+      log_push('Seed After', .Random.seed[2])
+    }
+
+    return (data)
   }
 }
 

--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -90,12 +90,12 @@ test_that("has functions work", {
   #.Random.seed is not recognized unless running RStudio
   # so checks involving randomness don't operate correctly in R CMD CHECK
 
-  #expect_true(has_no_randomness(noob)$state)
-  #expect_false(has_no_randomness(random)$state)
-  #expect_true(has_no_randomness(random_seed)$state)
+  expect_true(has_no_randomness(noob)$state)
+  expect_false(has_no_randomness(random)$state)
+  expect_true(has_no_randomness(random_seed)$state)
 
-  #expect_true(has_no_absolute_paths(noob)$state)
-  #expect_false(has_only_portable_paths(noob)$state)
+  expect_true(has_no_absolute_paths(noob)$state)
+  expect_false(has_only_portable_paths(noob)$state)
 
   miceps <- testthat::test_path("project_miceps")
 

--- a/tests/testthat/test-projects.R
+++ b/tests/testthat/test-projects.R
@@ -14,8 +14,8 @@ context("projects")
 
 
    proj_render(dir)
-   expect_equal(length(render_log_report(dir)$path), 7)
-   expect_equal(render_log_report(dir)$path[7], "LAST RENDERED")
+   expect_equal(length(render_log_report(dir)$path), 9)
+   expect_equal(tail(render_log_report(path)$path, 1), "LAST RENDERED")
 
 
    expect_true(fs::file_exists(session_file))

--- a/tests/testthat/test-projects.R
+++ b/tests/testthat/test-projects.R
@@ -15,7 +15,7 @@ context("projects")
 
    proj_render(dir)
    expect_equal(length(render_log_report(dir)$path), 9)
-   expect_equal(tail(render_log_report(path)$path, 1), "LAST RENDERED")
+   expect_equal(tail(render_log_report(dir)$path, 1), "LAST RENDERED")
 
 
    expect_true(fs::file_exists(session_file))

--- a/vignettes/retrospective.Rmd
+++ b/vignettes/retrospective.Rmd
@@ -14,7 +14,6 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
-Sys.setenv("IN_TESTTHAT" = TRUE)
 ```
 
 ```{r load, message=FALSE}


### PR DESCRIPTION
Great news!! I believe that I've now managed to fix all of the bugs we were having.

**`has_no_randomness()`**

`has_no_randomness()` now has no hard coding to solve the bug with `read_csv()`. I found a better solution involving the collection of seeds through the `read_csv()` shim before and after the function is called. Now, `read_csv()` doesn't interfere with the accuracy of the check!

**`proj_analyze()`**

There was also another issue where R CMD check couldn't capture `.Random.seed()` the same way that RStudio can, and therefore the render logs weren't generating properly (essentially, sometimes there can be no value of .Random.seed(), unless you've told R to do something random, so R CMD check couldn't find it). Fixed this by forcing `proj_render()` to do something random (and generate `.Random.seed`) before it renders the code. 

**Paper building**

Fixing the `.Random.seed` issue means that the paper now builds correctly when I run it! No more need for hard-coding.

**R CMD CHECK**

I also went ahead and un-commented-out all the checks that were breaking before. They all pass now! 