### PR TITLE
added exception for read_csv2

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -689,11 +689,17 @@ has_no_randomness <- function(path = ".") {
     filter(path == "Seed @ End") %>%
     select(func))
 
+  # Collect calls to read_csv and read_csv2 which affect random seed generation
   read_csv_calls <- grep("readr::read_csv", log$func)
+  read_csv2_calls <- grep("readr::read_csv2", log$func)
+
+  # Make sure all the calls are in one vector in order of occurrence
+  read_csv_calls <- append(read_csv_calls, read_csv2_calls)
+  read_csv_calls <- sort(read_csv_calls)
 
   read_csv_caused_problem <- FALSE
 
-  # If there are calls to read_csv
+  # If there are calls to read_csv / read_csv2:
   if (length(read_csv_calls)>0){
 
     # Go through each call one at a time

--- a/R/shims.R
+++ b/R/shims.R
@@ -129,9 +129,20 @@ read_csv <- function(file, ...) {
 
 read_csv2 <- function(file, ...) {
   if (interactive_log_on()) {
+    if (Sys.getenv("FERTILE_RENDER_MODE") == TRUE){
+      log_push('Seed Before', .Random.seed[2])
+    }
     log_push(file, "readr::read_csv2")
+
     check_path_safe(file, ... = "readr::read_csv2" )
-    readr::read_csv2(file, ...)
+
+    data <- readr::read_csv2(file, ...)
+
+    if (Sys.getenv("FERTILE_RENDER_MODE") == TRUE){
+      log_push('Seed After', .Random.seed[2])
+    }
+
+    return (data)
   }
 }
 


### PR DESCRIPTION
In testing other functions from `readr` for similar bugs, I found out that `read_csv2` has the same issue as `read_csv`. Addressed by modifying the shim in the same way as `read_csv` and adding it to the list of functions `has_no_randomness` has to look for. Besides these two, so far I have not come across any other functions from `readr` that cause the same problem.