### PR TITLE
looking into travis error

### DIFF
--- a/R/fertile.R
+++ b/R/fertile.R
@@ -974,6 +974,9 @@ edit_added_shims <- function(){
 
 disable_added_shims <- function(){
 
+
+  if(fs::dir_exists(Sys.getenv("HOME"))){
+
   # Get shims file path
   path_shims <- file.path(Sys.getenv("HOME"), "fertile_shims.R")
 
@@ -986,6 +989,7 @@ disable_added_shims <- function(){
   # Remove them from the global environment
   rm(list = function_names, envir = .GlobalEnv)
 
+  }
 
 }
 
@@ -995,9 +999,10 @@ disable_added_shims <- function(){
 enable_added_shims <- function(){
 
   # Get shims file path
-  path_shims <- file.path(Sys.getenv("HOME"), "fertile_shims.R")
-  base::source(path_shims)
-
+  if(fs::dir_exists(Sys.getenv("HOME"))){
+    path_shims <- file.path(Sys.getenv("HOME"), "fertile_shims.R")
+    base::source(path_shims)
+  }
 
 }
 

--- a/R/shims.R
+++ b/R/shims.R
@@ -336,7 +336,7 @@ read.ftable <- function(file, ...) {
 
 tbl <- function(src, ...) {
   if (interactive_log_on()) {
-    log_push(dplyr::db_desc(src$con), "dplyr::tbl")
+    log_push(class(src), "dplyr::tbl")
     dplyr::tbl(src, ...)
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -2,13 +2,18 @@
 #' @param libname a character string giving the library directory where the package defining the namespace was found
 #' @param pkgname a character string giving the name of the package
 .onAttach <- function(libname, pkgname){
-  enable_added_shims()
+  if (Sys.getenv("IN_TESTTHAT") != TRUE){
+    enable_added_shims()
+  }
 }
 
 #' Remove shims from environment when fertile is detached
 #' @param libpath a character string giving the complete path to the package
 .onDetach <- function(libpath){
-  disable_added_shims()
+  if (Sys.getenv("IN_TESTTHAT") != TRUE){
+    disable_added_shims()
+  }
+
 }
 
 

--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -90,6 +90,7 @@ test_that("has functions work", {
   #.Random.seed is not recognized unless running RStudio
   # so checks involving randomness don't operate correctly in R CMD CHECK
 
+  proj_render(noob)
   expect_true(has_no_randomness(noob)$state)
   expect_false(has_no_randomness(random)$state)
   expect_true(has_no_randomness(random_seed)$state)


### PR DESCRIPTION
There's a travis error where the `.onAttach` function (used to handle user-created shims) is causing problems. Since the user shims aren't testable in Travis at all (they use certain file paths that are dependent on being run on a traditional computer and not the Travis environment), I went ahead and disabled `.onAttach` and `.onDetach` when `testthat` is running. Not sure if that will deactivate it in Travis or not.

If not, how can you tell Travis to ignore a couple of lines of code (or a particular code file)? I can easily move `.onAttach` and `onDetach` to a different file if there's an easy way to make sure it gets ignored.

